### PR TITLE
Fix client portal link slug

### DIFF
--- a/paginas.php
+++ b/paginas.php
@@ -12,5 +12,6 @@ return [
     'productos' => [PageController::class, 'products'],
     'contact' => [PageController::class, 'contact'],
     'contacto' => [PageController::class, 'contact'],
+    'client-login' => [PageController::class, 'clientLogin'],
     'cliente-login' => [PageController::class, 'clientLogin'],
 ];

--- a/views/home.php
+++ b/views/home.php
@@ -147,7 +147,7 @@
                        </li>
                    </ul>
                    <div class="d-flex flex-wrap gap-2">
-                       <a href="index.php?page=cliente-login" class="btn btn-light text-primary-dark fw-semibold">Ingresar al portal</a>
+                       <a href="index.php?page=client-login" class="btn btn-light text-primary-dark fw-semibold">Ingresar al portal</a>
                        <a href="index.php?page=contact" class="btn btn-outline-light text-white">Solicitar acceso</a>
                    </div>
                </div>


### PR DESCRIPTION
## Summary
- update the client portal CTA on the home view to use the `client-login` slug
- add a route alias for `client-login` so the slug resolves to the client login view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbc1f33a08325b8ee3876f3ff0047